### PR TITLE
Add power-up spawning and collision handling

### DIFF
--- a/actors.py
+++ b/actors.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
-from typing import Optional, Set, List
+from typing import Optional, Set, List, TYPE_CHECKING
 from utils import Vec, add, cheb, legal_neighbors
+
+if TYPE_CHECKING:
+    from game import Game
 
 class Actor:
     def __init__(self, name: str, color: tuple[int,int,int], pos: Vec):
@@ -20,8 +23,14 @@ class Actor:
     def set_pos(self, p: Vec) -> None:
         self.pos = p
 
-    def set_pos(self, p: Vec) -> None:
+    def move(self, p: Vec, game: 'Game') -> None:
+        """Move to a new position and check for power-up collisions."""
         self.pos = p
+        for pu in list(getattr(game, 'powerups', [])):
+            if pu.pos == self.pos and pu.active:
+                pu.apply(self, game)
+                if not pu.active and pu in game.powerups:
+                    game.powerups.remove(pu)
 
 class HumanPlayer(Actor):
     """Human-controlled via key mapping handled by Game; this class validates moves."""

--- a/config.py
+++ b/config.py
@@ -24,6 +24,8 @@ class Config:
     fire_lifetime: int = 8           # measured in sub-turns
     fire_spawn_chance: float = 0.25  # attempt per sub-turn, at most 1 fire spawned
     respawn_delay: int = 5           # sub-turns until an actor respawns
+    powerup_spawn_chance: float = 0.1  # chance per sub-turn to spawn a power-up
+    powerup_max: int = 3
 
     # Colors
     colors: Dict[str, Color] = field(default_factory=lambda: {
@@ -56,7 +58,8 @@ class Config:
                 # known simple fields
                 for k in ("grid_w","grid_h","cell","margin","fps","min_start_dist",
                           "obstacles_enabled_default","obstacle_density","tree_ratio",
-                          "fire_max","fire_lifetime","fire_spawn_chance","respawn_delay"):
+                          "fire_max","fire_lifetime","fire_spawn_chance","respawn_delay",
+                          "powerup_spawn_chance","powerup_max"):
                     if k in data:
                         setattr(cfg, k, data[k])
                 # colors

--- a/game.py
+++ b/game.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-import sys
+import sys, random
 from typing import Optional, Set, Dict
 
 import pygame
@@ -8,6 +8,7 @@ from config import Config
 from utils import Vec, add, cheb, DIRS_8, pick_start_positions, generate_obstacles
 from fire import FireSystem
 from actors import HumanPlayer, HunterCPU, TargetCPU
+from powerups import PowerUp, TeleportPowerUp, HealPowerUp
 
 CAPTION = (
     "Hunter-Human-Target • QWE/ASD/ZXC • S=Skip • O=Obstacles • F=Fullscreen • R=Restart • ESC=Quit"
@@ -38,6 +39,9 @@ class Game:
         self.obstacles_styles: Dict[Vec, str] = {}
         # fires
         self.fire: FireSystem | None = None
+
+        # power-ups
+        self.powerups: list[PowerUp] = []
 
         # Controls: qwe/ asd / zxc ; S=skip
         self.key_to_dir: Dict[int, Optional[Vec]] = {
@@ -78,6 +82,9 @@ class Game:
         # init fires (clears any prior fires)
         self.fire = FireSystem(self.cfg, self.cfg.grid_w, self.cfg.grid_h)
         self.fire.clear()
+
+        # clear power-ups
+        self.powerups.clear()
 
         # Human → Hunter → Human → Hunter → Target
         self.turn_order = [self.human, self.hunter, self.human, self.hunter, self.target]
@@ -141,12 +148,34 @@ class Game:
             if a and a.alive and self.fire.cell_in_fire(a.pos):
                 self.kill_actor(a)
 
+    def maybe_spawn_powerup(self) -> None:
+        if len(self.powerups) >= self.cfg.powerup_max:
+            return
+        if random.random() >= self.cfg.powerup_spawn_chance:
+            return
+        occupied = {a.pos for a in [self.human, self.hunter, self.target] if a}
+        if self.obstacles_enabled:
+            occupied |= self.obstacles
+        occupied |= {pu.pos for pu in self.powerups}
+        for _ in range(20):
+            x = random.randrange(self.cfg.grid_w)
+            y = random.randrange(self.cfg.grid_h)
+            pos = (x, y)
+            if pos in occupied:
+                continue
+            if self.fire and self.fire.cell_in_fire(pos):
+                continue
+            cls = random.choice([TeleportPowerUp, HealPowerUp])
+            self.powerups.append(cls(pos))
+            break
+
     def post_step(self) -> None:
         # Fires expire, perhaps spawn one, then check for any immediate kills
         if self.fire:
             self.fire.update(self.step_counter)
             self.fire.maybe_spawn(self.step_counter, self.obstacles, self.obstacles_styles)
             self.check_fire_kills()
+        self.maybe_spawn_powerup()
         # handle respawn countdowns
         self.decrement_respawns()
 
@@ -193,6 +222,13 @@ class Game:
                 cy = ry + cell // 2
                 r = max(3, cell // 3)
                 pygame.draw.circle(self.screen, rock_color, (cx, cy), r)
+
+    def draw_powerups(self) -> None:
+        if not self.powerups:
+            return
+        assert self.screen
+        for pu in self.powerups:
+            pu.draw(self.screen, self.cfg)
 
     
 
@@ -251,6 +287,7 @@ class Game:
             if key in self.key_to_dir:
                 delta = self.key_to_dir[key]
                 if self.human.try_move(delta, self.cfg.grid_w, self.cfg.grid_h, self.obstacles, self.obstacles_enabled):
+                    self.human.move(self.human.pos, self)
                     if self.fire and self.fire.cell_in_fire(self.human.pos):
                         self.kill_actor(self.human)
                     self.advance_turn()
@@ -286,14 +323,14 @@ class Game:
                 elif current is self.hunter:
                     if self.hunter.alive:
                         nxt = self.hunter.decide(self.target.pos, self.cfg.grid_w, self.cfg.grid_h, self.obstacles, self.obstacles_enabled)
-                        self.hunter.set_pos(nxt)
+                        self.hunter.move(nxt, self)
                         if self.fire and self.fire.cell_in_fire(self.hunter.pos):
                             self.kill_actor(self.hunter)
                     self.advance_turn(); self.check_win_after_move(); self.post_step()
                 elif current is self.target:
                     if self.target.alive:
                         nxt = self.target.decide(self.human.pos, self.hunter.pos, self.cfg.grid_w, self.cfg.grid_h, self.obstacles, self.obstacles_enabled)
-                        self.target.set_pos(nxt)
+                        self.target.move(nxt, self)
                         if self.fire and self.fire.cell_in_fire(self.target.pos):
                             self.kill_actor(self.target)
                     self.advance_turn(); self.check_win_after_move(); self.post_step()
@@ -303,6 +340,7 @@ class Game:
             self.draw_obstacles()
             if self.fire:
                 self.fire.draw(self.screen, self.cfg, self.step_counter)
+            self.draw_powerups()
             assert self.human and self.hunter and self.target
             if self.target.alive:
                 self.draw_actor(self.target.pos, self.cfg.colors["target"])  # draw target first so chasers on top

--- a/powerups.py
+++ b/powerups.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import pygame
+
+from utils import Vec
+
+if TYPE_CHECKING:
+    from game import Game
+    from actors import Actor
+
+class PowerUp:
+    """Base power-up with position and sprite rendering"""
+    def __init__(self, pos: Vec):
+        self.pos = pos
+        self.active = True
+
+    def apply(self, actor: 'Actor', game: 'Game') -> None:
+        """Apply the effect to the actor; by default simply deactivates."""
+        self.active = False
+
+    def draw(self, screen, cfg) -> None:
+        """Default drawing: small white circle."""
+        cell = cfg.cell
+        cx = self.pos[0] * cell + cell // 2
+        cy = self.pos[1] * cell + cell // 2
+        r = max(3, cell // 3)
+        pygame.draw.circle(screen, (250, 250, 250), (cx, cy), r)
+
+class TeleportPowerUp(PowerUp):
+    color = (200, 60, 200)
+
+    def apply(self, actor: 'Actor', game: 'Game') -> None:
+        super().apply(actor, game)
+        actor.set_pos(game.find_safe_spawn(actor.pos))
+
+    def draw(self, screen, cfg) -> None:
+        cell = cfg.cell
+        cx = self.pos[0] * cell + cell // 2
+        cy = self.pos[1] * cell + cell // 2
+        r = max(3, cell // 3)
+        points = [(cx, cy - r), (cx + r, cy), (cx, cy + r), (cx - r, cy)]
+        pygame.draw.polygon(screen, self.color, points)
+
+class HealPowerUp(PowerUp):
+    color = (255, 200, 40)
+
+    def apply(self, actor: 'Actor', game: 'Game') -> None:
+        super().apply(actor, game)
+        actor.deaths = max(0, actor.deaths - 1)
+
+    def draw(self, screen, cfg) -> None:
+        cell = cfg.cell
+        cx = self.pos[0] * cell + cell // 2
+        cy = self.pos[1] * cell + cell // 2
+        r = max(3, cell // 3)
+        pygame.draw.circle(screen, self.color, (cx, cy), r)


### PR DESCRIPTION
## Summary
- introduce `PowerUp` classes such as teleport and heal with draw logic
- spawn and render random power-ups during gameplay
- actors trigger power-up effects when moving onto them

## Testing
- `python -m py_compile actors.py powerups.py game.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_68abc63604e8832ca42af4c3498bd5fa