### PR TITLE
Replace teleport and heal powerups with speed and time stop

### DIFF
--- a/actors.py
+++ b/actors.py
@@ -15,6 +15,9 @@ class Actor:
         self.dead: bool = False
         self.respawn_ticks: int = 0
         self.last_death_pos: Optional[Vec] = None
+        # power-up effects
+        self.speed_turns: int = 0   # number of upcoming turns with double-step
+        self.skip_turns: int = 0    # number of upcoming turns to skip
 
     @property
     def alive(self) -> bool:


### PR DESCRIPTION
## Summary
- add SpeedPowerUp for two-step moves and TimeStopPowerUp that skips opponent turns
- allow actors to track active speed and skip-turn effects
- integrate new power-ups into spawn logic and turn handling, removing teleport/heal

## Testing
- `python -m py_compile actors.py game.py powerups.py`


------
https://chatgpt.com/codex/tasks/task_e_68abcaa0afcc832c93c2ee5b21daf8be