### PR TITLE
Allow configuring power-up behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ uv sync
 uv run main.py
 ```
 
+## Configuration
+Gameplay options can be tweaked by editing `config.json`. In addition to grid
+and fire settings, you can now control power-up behavior:
+
+- `powerup_length`: number of turns a collected power-up remains effective
+- `powerup_lifetime`: how many sub-turns a power-up stays on the map
+- `powerup_spawn_chance`: chance per sub-turn to spawn a power-up
+- `powerup_max`: maximum simultaneous power-ups on the board
+
 ## Controls
 - Movement: **QWE / ASD / ZXC** (8 directions)
 - **S** = Skip turn

--- a/config.json
+++ b/config.json
@@ -12,6 +12,10 @@
   "fire_lifetime": 12,
   "fire_spawn_chance": 0.33,
   "respawn_delay": 5,
+  "powerup_length": 2,
+  "powerup_lifetime": 20,
+  "powerup_spawn_chance": 0.1,
+  "powerup_max": 3,
   "colors": {
     "bg": [
       18,

--- a/config.py
+++ b/config.py
@@ -26,6 +26,8 @@ class Config:
     respawn_delay: int = 5           # sub-turns until an actor respawns
     powerup_spawn_chance: float = 0.1  # chance per sub-turn to spawn a power-up
     powerup_max: int = 3
+    powerup_length: int = 2          # effect duration in turns
+    powerup_lifetime: int = 20       # sub-turns a power-up stays on the map
 
     # Colors
     colors: Dict[str, Color] = field(default_factory=lambda: {
@@ -59,7 +61,7 @@ class Config:
                 for k in ("grid_w","grid_h","cell","margin","fps","min_start_dist",
                           "obstacles_enabled_default","obstacle_density","tree_ratio",
                           "fire_max","fire_lifetime","fire_spawn_chance","respawn_delay",
-                          "powerup_spawn_chance","powerup_max"):
+                          "powerup_spawn_chance","powerup_max","powerup_length","powerup_lifetime"):
                     if k in data:
                         setattr(cfg, k, data[k])
                 # colors

--- a/game.py
+++ b/game.py
@@ -148,6 +148,13 @@ class Game:
             if a and a.alive and self.fire.cell_in_fire(a.pos):
                 self.kill_actor(a)
 
+    def update_powerups(self) -> None:
+        """Tick power-ups and remove any that expired."""
+        for pu in list(self.powerups):
+            pu.tick()
+            if not pu.active:
+                self.powerups.remove(pu)
+
     def maybe_spawn_powerup(self) -> None:
         if len(self.powerups) >= self.cfg.powerup_max:
             return
@@ -166,7 +173,7 @@ class Game:
             if self.fire and self.fire.cell_in_fire(pos):
                 continue
             cls = random.choice([SpeedPowerUp, TimeStopPowerUp])
-            self.powerups.append(cls(pos))
+            self.powerups.append(cls(pos, self.cfg.powerup_lifetime))
             break
 
     def post_step(self) -> None:
@@ -175,6 +182,7 @@ class Game:
             self.fire.update(self.step_counter)
             self.fire.maybe_spawn(self.step_counter, self.obstacles, self.obstacles_styles)
             self.check_fire_kills()
+        self.update_powerups()
         self.maybe_spawn_powerup()
         # handle respawn countdowns
         self.decrement_respawns()

--- a/powerups.py
+++ b/powerups.py
@@ -11,15 +11,22 @@ if TYPE_CHECKING:
 
 
 class PowerUp:
-    """Base power-up with position and sprite rendering"""
+    """Base power-up with position, lifetime, and sprite rendering"""
 
-    def __init__(self, pos: Vec):
+    def __init__(self, pos: Vec, lifetime: int):
         self.pos = pos
         self.active = True
+        self.lifetime = lifetime
 
     def apply(self, actor: 'Actor', game: 'Game') -> None:
         """Apply the effect to the actor; by default simply deactivates."""
         self.active = False
+
+    def tick(self) -> None:
+        """Advance lifetime and deactivate when expired."""
+        self.lifetime -= 1
+        if self.lifetime <= 0:
+            self.active = False
 
     def draw(self, screen, cfg) -> None:
         """Default drawing: small white circle."""
@@ -35,7 +42,7 @@ class SpeedPowerUp(PowerUp):
 
     def apply(self, actor: 'Actor', game: 'Game') -> None:
         super().apply(actor, game)
-        actor.speed_turns = 2
+        actor.speed_turns = game.cfg.powerup_length
 
     def draw(self, screen, cfg) -> None:
         cell = cfg.cell
@@ -51,16 +58,17 @@ class TimeStopPowerUp(PowerUp):
 
     def apply(self, actor: 'Actor', game: 'Game') -> None:
         super().apply(actor, game)
+        dur = game.cfg.powerup_length
         if actor is game.human and game.hunter:
-            game.hunter.skip_turns = max(game.hunter.skip_turns, 2)
+            game.hunter.skip_turns = max(game.hunter.skip_turns, dur)
         elif actor is game.hunter and game.human:
-            game.human.skip_turns = max(game.human.skip_turns, 2)
+            game.human.skip_turns = max(game.human.skip_turns, dur)
         else:
             # if target picks it, slow both chasers
             if game.human:
-                game.human.skip_turns = max(game.human.skip_turns, 2)
+                game.human.skip_turns = max(game.human.skip_turns, dur)
             if game.hunter:
-                game.hunter.skip_turns = max(game.hunter.skip_turns, 2)
+                game.hunter.skip_turns = max(game.hunter.skip_turns, dur)
 
     def draw(self, screen, cfg) -> None:
         cell = cfg.cell


### PR DESCRIPTION
## Summary
- add config options for power-up effect duration, lifetime, spawn chance, and maximum
- expire power-ups over time and apply configured durations
- document power-up settings in README

## Testing
- `python -m py_compile config.py game.py powerups.py actors.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac81ae61b8832cbff52e5c85191ce5