### PR TITLE
Add Android build configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
 plugins {
-    kotlin("jvm") version "1.9.22"
+    kotlin("android") version "1.9.22"
+    id("com.android.application") version "8.2.0"
     application
 }
 
 repositories {
+    google()
     mavenCentral()
 }
 
@@ -12,6 +14,37 @@ dependencies {
     implementation("com.badlogicgames.gdx:gdx:1.12.0")
     implementation("com.badlogicgames.gdx:gdx-backend-lwjgl3:1.12.0")
     implementation("com.badlogicgames.gdx:gdx-platform:1.12.0:natives-desktop")
+
+    // Android backend
+    implementation("com.badlogicgames.gdx:gdx-backend-android:1.12.0")
+    implementation("com.badlogicgames.gdx:gdx-platform:1.12.0:natives-armeabi")
+    implementation("com.badlogicgames.gdx:gdx-platform:1.12.0:natives-armeabi-v7a")
+    implementation("com.badlogicgames.gdx:gdx-platform:1.12.0:natives-arm64-v8a")
+    implementation("com.badlogicgames.gdx:gdx-platform:1.12.0:natives-x86")
+    implementation("com.badlogicgames.gdx:gdx-platform:1.12.0:natives-x86_64")
+}
+
+android {
+    namespace = "com.boardrockchess"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.boardrockchess"
+        minSdk = 21
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
 }
 
 application {
@@ -19,5 +52,5 @@ application {
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(17)
 }

--- a/proguard-rules.pro
+++ b/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Add project specific ProGuard rules here.
+# See https://developer.android.com/studio/build/shrink-code for details.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,16 @@
+pluginManagement {
+    repositories {
+        google()
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 rootProject.name = "BoardRockChess"


### PR DESCRIPTION
## Summary
- enable Android plugin and configuration for the project
- add Android backend dependencies and proguard rules
- configure plugin and dependency repositories

## Testing
- `gradle --no-daemon --console=plain assembleDebug` *(fails: Cannot add extension with name 'kotlin', as there is an extension already registered with that name)*


------
https://chatgpt.com/codex/tasks/task_e_68acb8b49f90832ca18cfe8d2dea291d